### PR TITLE
Add soft delete support / bump to 6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/scout": "^6.0"
+        "laravel/scout": "^6.1"
     },
      "require-dev": {
         "mockery/mockery": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/scout": "^5.0"
+        "laravel/scout": "^6.0"
     },
      "require-dev": {
         "mockery/mockery": "~1.0",

--- a/tests/DatabaseEngineTest.php
+++ b/tests/DatabaseEngineTest.php
@@ -20,6 +20,7 @@ final class DatabaseEngineTest extends AbstractTestCase
         $queryBuilder = Mockery::mock('Illuminate\Database\Query\Builder');
         $modelReturningEmpty = Mockery::mock('Testing\Fixtures\TestModel');
         $modelReturningEmpty->shouldReceive('toSearchableArray')->andReturn([]);
+        $modelReturningEmpty->shouldReceive('scoutMetadata')->andReturn([]);
         $manager->shouldReceive('table')->with('scout_index')->andReturn($queryBuilder);
         $queryBuilder->shouldReceive('updateOrInsert')->with([
             'index'    => 'table',
@@ -27,7 +28,7 @@ final class DatabaseEngineTest extends AbstractTestCase
         ], [
             'objectID' => 1,
             'index'    => 'table',
-            'entry'    => '[1]',
+            'entry'    => '{"id":1}',
         ]);
 
         $engine = new DatabaseEngine($manager);
@@ -103,7 +104,10 @@ final class DatabaseEngineTest extends AbstractTestCase
             )
             ->andReturn($queryBuilder)
             ->shouldReceive('where')
-            ->with('entry', 'like', '%"foo":"1"%')
+            ->with('entry', 'like', '%"foo":1%')
+            ->andReturn($queryBuilder)
+            ->shouldReceive('where')
+            ->with('entry', 'like', '%"bar":"string"%')
             ->andReturn($queryBuilder)
             ->shouldReceive('get')
             ->andReturn([1, 2, 3]);
@@ -111,6 +115,7 @@ final class DatabaseEngineTest extends AbstractTestCase
         $engine = new DatabaseEngine($manager);
         $builder = new Builder(new TestModel(), 'zonda');
         $builder->where('foo', 1);
+        $builder->where('bar', 'string');
         $result = $engine->search($builder);
         $this->assertSame($result, [
             'results' => [1, 2, 3],


### PR DESCRIPTION
Adds proper changes needed to support soft deletes. ~~Technically, it's still broken, but I have [a merge request](https://github.com/laravel/scout/pull/321) that has been accepted into laravel/scout that is pending a tag / release. Once that gets tagged, then it'll work fully. No need to delay though as the soft delete functionality won't effect existing functionality.~~

Bumped the scout version to 6.1 and added the `flush` method to `DatabaseEngine`, which is required by the updated abstract class.

Fixed a logic issue in `performSearch` where non-string based queries weren't being found correctly. Now, it will use `json_encode` to search for the proper query string in the database.