### PR TITLE
Add Exception use statement

### DIFF
--- a/src/DatabaseEngine.php
+++ b/src/DatabaseEngine.php
@@ -2,6 +2,7 @@
 
 namespace BoxedCode\Laravel\Scout;
 
+use Exception;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;


### PR DESCRIPTION
I tried to add an index and got a message stating `Class "BoxedCode\Laravel\Scout\Exception" not found` because of the missing import.

See https://github.com/boxed-code/laravel-scout-database/blob/master/src/DatabaseEngine.php#L195